### PR TITLE
No longer depend on nvim-lspconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-          git clone --depth 1 https://github.com/neovim/nvim-lspconfig ~/.local/share/nvim/site/pack/vendor/start/nvim-lspconfig
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Requires 0.7+.
 
 ```lua
-use({ "mhanberg/elixir.nvim", requires = { "neovim/nvim-lspconfig", "nvim-lua/plenary.nvim" }})
+use({ "mhanberg/elixir.nvim", requires = { "nvim-lua/plenary.nvim" }})
 ```
 
 ## Getting Started
@@ -31,7 +31,7 @@ elixir.setup({
   -- specify a repository and branch
   repo = "mhanberg/elixir-ls", -- defaults to elixir-lsp/elixir-ls
   branch = "mh/all-workspace-symbols", -- defaults to nil, just checkouts out the default branch, mutually exclusive with the `tag` option
-  tag = "v0.9.0", -- defaults to nil, mutually exclusive with the `branch` option
+  tag = "v0.10.0", -- defaults to nil, mutually exclusive with the `branch` option
 
   -- default settings, use the `settings` function to override settings
   settings = elixir.settings({


### PR DESCRIPTION
Revert "Revert "feat: no longer require nvim-lspconfig (#27)" (#30)"

This reverts commit 67bb9a1c504fc522391b83f1f46be1a1ef98918a.

This reverts the #30, which is a revert of #27. We can merge this when
`vim.fs` and `vim.lsp.start` make it into stable.

Closes #5 Lose dependency on lspconfig
