### PR TITLE
Support for vim-projectionist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 > Note: This plugin does not provide autocompletion, I recommend using [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 
+## Features
+
+- [ElixirLS](https://github.com/elixir-lsp/elixir-ls) installation and configuration (uses the Neovim built-in LSP client)
+- `:Mix` command with autocomplete
+- [vim-projectionist](https://github.com/tpope/vim-projectionist) support
+
 ## Install
 
 Requires 0.7+.
@@ -80,7 +86,9 @@ elixir.setup({
 
 ## Features
 
-### Automatic ElixirLS Installation
+### Language Server
+
+#### Automatic ElixirLS Installation
 
 When a compatible installation of ELixirLS is not found, you will be prompted to install it. The plugin will download the source code to the `.elixir_ls` directory and compile it using the Elixir and OTP versions used by your current project.
 
@@ -90,17 +98,17 @@ Caveat: This currently downloads the language server into the `.elixir_ls` direc
 
 ![auto-install-elixirls](https://user-images.githubusercontent.com/5523984/160333851-94d448d9-5c80-458c-aa0d-4c81528dde8f.gif)
 
-### Root Path Detection
+#### Root Path Detection
 
 `elixir.nvim` should be able to properly set the root directory for umbrella and non-umbrella apps. The nvim-lspconfig project's root detection doesn't properly account for umbrella projects.
 
-### Run Tests
+#### Run Tests
 
 ElixirLS provides a codelens to identify and run your tests. If you configure `enableTestLenses = true` in the settings table, you will see the codelens as virtual text in your editor and can run them with `vim.lsp.codelens.run()`.
 
 ![elixir-test-lens](https://user-images.githubusercontent.com/5523984/159722637-ef1586d5-9d47-4e1a-b68b-6a90ad744098.gif)
 
-### Manipulate Pipes
+#### Manipulate Pipes
 
 The LS has the ability to convert the expression under the cursor form a normal function call to a "piped" function all (and vice versa).
 
@@ -109,7 +117,7 @@ The LS has the ability to convert the expression under the cursor form a normal 
 
 ![manipulate_pipes](https://user-images.githubusercontent.com/5523984/160508641-cedb6ebf-3ec4-4229-9708-aa360b15a2d5.gif)
 
-### Expand Macro
+#### Expand Macro
 
 You can highlight a macro call in visual mode and "expand" the macro, opening a floating window with the results.
 
@@ -117,13 +125,13 @@ You can highlight a macro call in visual mode and "expand" the macro, opening a 
 
 ![expand_macro](https://user-images.githubusercontent.com/5523984/162372669-4782baba-1889-4145-8a4f-e3bf13a6450d.gif)
 
-### Restart
+#### Restart
 
 You can restart the LS by using the restart command. This is useful if you think the LS has gotten into a weird state. It will send the restart command and then save and reload your current buffer to re-attach the client.
 
 `:ElixirRestart`
 
-### OutputPanel
+#### OutputPanel
 
 You can see the logs for ElixirLS via the output panel. By default opens the buffer in a horizontal split window.
 
@@ -142,6 +150,16 @@ You can run any `mix` command in your project, complete with... autocomplete!
 `:Mix compile --force`
 
 ![elixir-nvim-mix-demo](https://user-images.githubusercontent.com/5523984/181859468-19d47a55-3f63-4af5-8698-4b5dd3459141.gif)
+
+### Projectionist
+
+[vim-projectionist](https://github.com/tpope/vim-projectionist) definitions are provided for:
+
+- Elixir files
+- Phoenix Views
+- Phoenix Controllers
+- Phoenix Channels
+- Wallaby/Hound Feature tests
 
 ### Debugger
 

--- a/lua/elixir/init.lua
+++ b/lua/elixir/init.lua
@@ -1,5 +1,6 @@
 local language_server = require("elixir.language_server")
 local mix = require("elixir.mix")
+local projectionist = require("elixir.projectionist")
 
 local M = {}
 
@@ -8,6 +9,7 @@ M.open_output_panel = language_server.open_output_panel
 
 function M.setup(opts)
 	mix.setup()
+	projectionist.setup()
 	language_server.setup(opts)
 end
 

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -1,0 +1,101 @@
+local M = {}
+
+local config = {
+	["mix.exs"] = {
+		["lib/**/views/*_view.ex"] = {
+			type = "view",
+			alternate = "test/{dirname}/views/{basename}_view_test.exs",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}View do",
+				"  use {dirname|camelcase|capitalize}, :view",
+				"end",
+			},
+		},
+		["test/**/views/*_view_test.exs"] = {
+			alternate = "lib/{dirname}/views/{basename}_view.ex",
+			type = "test",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ViewTest do",
+				"  use ExUnit.Case, async: true",
+				"",
+				"  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}View",
+				"end",
+			},
+		},
+		["lib/**/controllers/*_controller.ex"] = {
+			type = "controller",
+			alternate = "test/{dirname}/controllers/{basename}_controller_test.exs",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Controller do",
+				"  use {dirname|camelcase|capitalize}, :controller",
+				"end",
+			},
+		},
+		["test/**/controllers/*_controller_test.exs"] = {
+			alternate = "lib/{dirname}/controllers/{basename}_controller.ex",
+			type = "test",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ControllerTest do",
+				"  use {dirname|camelcase|capitalize}.ConnCase, async: true",
+				"end",
+			},
+		},
+		["lib/**/channels/*_channel.ex"] = {
+			type = "channel",
+			alternate = "test/{dirname}/channels/{basename}_channel_test.exs",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Channel do",
+				"  use {dirname|camelcase|capitalize}, :channel",
+				"end",
+			},
+		},
+		["test/**/channels/*_channel_test.exs"] = {
+			alternate = "lib/{dirname}/channels/{basename}_channel.ex",
+			type = "test",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ChannelTest do",
+				"  use {dirname|camelcase|capitalize}.ChannelCase, async = true",
+				"",
+				"  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Channel",
+				"end",
+			},
+		},
+		["test/**/features/*_test.exs"] = {
+			type = "feature",
+			template = {
+				"defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Test do",
+				"  use {dirname|camelcase|capitalize}.FeatureCase, async = true",
+				"end",
+			},
+		},
+		["lib/*.ex"] = {
+			alternate = "test/{}_test.exs",
+			type = "source",
+			template = { "defmodule {camelcase|capitalize|dot} do", "end" },
+		},
+		["test/*_test.exs"] = {
+			alternate = "lib/{}.ex",
+			type = "test",
+			template = {
+				"defmodule {camelcase|capitalize|dot}Test do",
+				"  use ExUnit.Case, async: true",
+				"",
+				"  alias {camelcase|capitalize|dot}",
+				"end",
+			},
+		},
+	},
+}
+
+function M.setup()
+	local new_heuristics
+	if vim.g.projectionist_heuristics then
+		new_heuristics = vim.tbl_extend(vim.g.projectionist_heuristics, config, { force = true })
+	else
+		new_heuristics = config
+	end
+
+	vim.g.projectionist_heuristics = new_heuristics
+end
+
+return M


### PR DESCRIPTION
Provides vim-projectionist heuristics for the following file types, including templates to create the files if they don't exist.

- Elixir files
- Phoenix Views
- Phoenix Controllers
- Phoenix Channels
- Wallaby/Hound Feature tests
