### PR TITLE
Allow locally installed elixir-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ elixir.setup({
   branch = "mh/all-workspace-symbols", -- defaults to nil, just checkouts out the default branch, mutually exclusive with the `tag` option
   tag = "v0.9.0", -- defaults to nil, mutually exclusive with the `branch` option
 
+  -- alternatively, point to an existing elixir-ls installation (optional)
+  cmd = "/usr/local/bin/elixir-ls.sh",
+
   -- default settings, use the `settings` function to override settings
   settings = elixir.settings({
     dialyzerEnabled = true,

--- a/lua/elixir/language_server/init.lua
+++ b/lua/elixir/language_server/init.lua
@@ -261,26 +261,28 @@ function M.setup(opts)
 		on_new_config = function(new_config, new_root_dir)
 			new_opts = make_opts(opts)
 
-			local cmd = M.command({
-				path = tostring(install_dir),
-				repo = new_opts.repo,
-				ref = new_opts.ref,
-				versions = Version.get(),
-			})
+			if not opts["cmd"] then
+				local cmd = M.command({
+					path = tostring(install_dir),
+					repo = new_opts.repo,
+					ref = new_opts.ref,
+					versions = Version.get(),
+				})
 
-			if not cmd:exists() then
-				vim.ui.select({ "Yes", "No" }, { prompt = "Install ElixirLS" }, function(choice)
-					if choice == "Yes" then
-						install_elixir_ls(vim.tbl_extend("force", new_opts, { install_path = cmd:parent() }))
-					end
-				end)
+				if not cmd:exists() then
+					vim.ui.select({ "Yes", "No" }, { prompt = "Install ElixirLS" }, function(choice)
+						if choice == "Yes" then
+							install_elixir_ls(vim.tbl_extend("force", new_opts, { install_path = cmd:parent() }))
+						end
+					end)
 
-				return
-			else
-				local updated_config = new_config
-				updated_config.cmd = { tostring(cmd) }
+					return
+				else
+					local updated_config = new_config
+					updated_config.cmd = { tostring(cmd) }
 
-				return updated_config
+					return updated_config
+				end
 			end
 		end,
 		handlers = {


### PR DESCRIPTION
This patch allows you to use `cmd = "path"` in the settings so that you can point to an already installed `elixir-ls`. This is useful is you manage those yourself or if you are for example hacking on `elixir-ls` improvements in your local development environment.