### PR TITLE
Conflict-free example bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ elixir.setup({
     vim.keymap.set("n", "<space>tp", ":ElixirToPipe<cr>", map_opts)
     vim.keymap.set("v", "<space>em", ":ElixirExpandMacro<cr>", map_opts)
 
-    -- standard lsp keybinds
-    vim.keymap.set("n", "df", "<cmd>lua vim.lsp.buf.formatting_seq_sync()<cr>", map_opts)
-    vim.keymap.set("n", "gd", "<cmd>lua vim.diagnostic.open_float()<cr>", map_opts)
-    vim.keymap.set("n", "dt", "<cmd>lua vim.lsp.buf.definition()<cr>", map_opts)
-    vim.keymap.set("n", "K", "<cmd>lua vim.lsp.buf.hover()<cr>", map_opts)
-    vim.keymap.set("n", "gD","<cmd>lua vim.lsp.buf.implementation()<cr>", map_opts)
-    vim.keymap.set("n", "1gD","<cmd>lua vim.lsp.buf.type_definition()<cr>", map_opts)
+    -- bindings for standard LSP functions.
+    vim.keymap.set("n", "<space>df", "<cmd>lua vim.lsp.buf.formatting_seq_sync()<cr>", map_opts)
+    vim.keymap.set("n", "<space>gd", "<cmd>lua vim.diagnostic.open_float()<cr>", map_opts)
+    vim.keymap.set("n", "<space>dt", "<cmd>lua vim.lsp.buf.definition()<cr>", map_opts)
+    vim.keymap.set("n", "<space>K", "<cmd>lua vim.lsp.buf.hover()<cr>", map_opts)
+    vim.keymap.set("n", "<space>gD","<cmd>lua vim.lsp.buf.implementation()<cr>", map_opts)
+    vim.keymap.set("n", "<space>1gD","<cmd>lua vim.lsp.buf.type_definition()<cr>", map_opts)
     -- keybinds for fzf-lsp.nvim: https://github.com/gfanto/fzf-lsp.nvim
     -- you could also use telescope.nvim: https://github.com/nvim-telescope/telescope.nvim
     -- there are also core vim.lsp functions that put the same data in the loclist
-    vim.keymap.set("n", "gr", ":References<cr>", map_opts)
-    vim.keymap.set("n", "g0", ":DocumentSymbols<cr>", map_opts)
-    vim.keymap.set("n", "gW", ":WorkspaceSymbols<cr>", map_opts)
+    vim.keymap.set("n", "<space>gr", ":References<cr>", map_opts)
+    vim.keymap.set("n", "<space>g0", ":DocumentSymbols<cr>", map_opts)
+    vim.keymap.set("n", "<space>gW", ":WorkspaceSymbols<cr>", map_opts)
     vim.keymap.set("n", "<leader>d", ":Diagnostics<cr>", map_opts)
 
 


### PR DESCRIPTION
As discussed in #51. This just add a `<space>` to the existing examples, that should not clash with anything in (Neo)Vim’s default set-up.