### PR TITLE
typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requires 0.8.
     local elixir = require("elixir")
 
     elixir.setup {
-      settings = elixirls.settings {
+      settings = elixir.settings {
         dialyzerEnabled = false,
         enableTestLenses = false,
       },


### PR DESCRIPTION
I noticed this typo when trying out the plugin. Please ignore if I'm mistaken.